### PR TITLE
Fixed a typo (logging.log) and use "repr(coords)" to make coords into…

### DIFF
--- a/gpsdeasy.py
+++ b/gpsdeasy.py
@@ -315,7 +315,7 @@ class gpsdeasy(plugins.Plugin):
 
     def on_handshake(self, agent, filename, access_point, client_station):
         coords = self.gpsd.get_current('tpv')
-        logging.log("!!!!! " + coords)
+        logging.debug("!!!!! " + repr(coords))
         if 'lat' and 'lon' in coords:
             gps_filename = filename.replace(".pcap", ".gps.json")
             logging.info(f"[gpsdeasy] saving GPS to {gps_filename} ({coords})")


### PR DESCRIPTION
… a string

My pwny was not saving .gps.json files, even though I had gps lock. I saw an error in the logs on line 318:

  File "/usr/local/share/pwnagotchi/custom-plugins/gpsdeasy.py", line 318, in on_handshake
    logging.log("!!!!! " + coords)
                ~~~~~~~~~^~~~~~~~
TypeError: can only concatenate str (not "dict") to str

Then it didn't like logging.log, so I switched to .debug. there apparently is a logging.log, but it takes different arguments (that I do not know)